### PR TITLE
HMIS-1302 Add functional tests with correct payload

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/hmi/direct/PostDirectListingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/hmi/direct/PostDirectListingTest.java
@@ -10,8 +10,12 @@ import uk.gov.hmcts.reform.hmi.helper.HeaderHelper;
 import uk.gov.hmcts.reform.hmi.helper.RestClientHelper;
 
 import java.io.IOException;
-import java.net.UnknownHostException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Map;
+import java.util.Random;
+
+import static uk.gov.hmcts.reform.hmi.helper.FileHelper.getJsonPayloadFileAsString;
 
 /**
  * Functional tests for the endpoint used by different consumers (/listings).
@@ -23,6 +27,14 @@ class PostDirectListingTest {
     @Autowired
     RestClientHelper restClientHelper;
 
+    private final Random rand;
+
+    private static String randomHearingId;
+
+    public PostDirectListingTest()  throws NoSuchAlgorithmException {
+        rand = SecureRandom.getInstanceStrong();
+    }
+
     @BeforeEach
     void setup() {
         RestAssured.baseURI = "https://sds-api-mgmt.staging.platform.hmcts.net/hmi";
@@ -30,11 +42,14 @@ class PostDirectListingTest {
 
     /**
      * Test with a valid set of headers, but empty body, response should return 400.
+     * Need to fix the payload once LA deploy DirectListing config on their SIT environment.
      */
     @Test
-    void postDirectListingFail() throws UnknownHostException {
+    void postDirectListingFail() throws IOException {
+        randomHearingId = String.format("HMI_%s", rand.nextInt(999_999_999));
         restClientHelper.performSecurePostRequestAndValidate(
-                "{}",
+                getJsonPayloadFileAsString("directlistings/create-direct-listings-request-payload.json")
+                        .replace("HMI_CASE_LISTING_ID", randomHearingId),
                 HeaderHelper.createHeaders("SNL"),
                 "/listings",
                 "",

--- a/src/functionalTest/resources/directlistings/create-direct-listings-request-payload.json
+++ b/src/functionalTest/resources/directlistings/create-direct-listings-request-payload.json
@@ -1,0 +1,64 @@
+{
+  "listingRequest": {
+    "meta": {},
+    "_case": {
+      "caseIdHMCTS": "160001303611",
+      "caseListingRequestId": "HMI_CASE_LISTING_ID",
+      "caseVersionID": "",
+      "caseTitle": "1600013036",
+      "caseJurisdiction": "B",
+      "caseCourt": {
+        "locationType": "Court",
+        "locationReferenceType": "EXTERNAL",
+        "locationId": ""
+      },
+      "caseRegistered": "2016-06-15T00:00:00+00:00",
+      "caseReportingRestrictions": "",
+      "caseClassifications": [
+        {
+          "caseClassificationService": "B001",
+          "caseClassificationType": "CASE",
+          "caseClassificationSubType": "S"
+        }
+      ]
+    },
+    "entities": [
+      {
+        "entityId": "765855",
+        "entityTypeCode": "IND",
+        "entityRoleCode": "DEFE",
+        "entitySubType": {
+          "entityClassCode": "PERSON",
+          "entityFirstName": "JCone",
+          "entityLastName": "JCone",
+          "entityDateOfBirth": "1998-01-01"
+        },
+        "entityOffences": [
+          {
+            "offenceId": "1",
+            "offenceClass": "3",
+            "offenceTitle": "Theft from a shop",
+            "offenceWording": "On 01/01/2015 at town, stole article, to the value of \u00A32464.00, belonging to person.",
+            "offenceLegislation": "Contrary to section 1(1) and 7 of the Theft Act 1968.",
+            "offenceDate": "2015-01-01"
+          }
+        ]
+      }
+    ],
+    "listing": {
+      "listingType": "G",
+      "listingSessions": [
+        {
+          "listingRoom": {
+            "locationType": "Room",
+            "locationReferenceType": "EXTERNAL",
+            "locationId": "1083"
+          },
+          "listingStartDate": "2016-06-15T15:39:29+00:00",
+          "listingDuration": 5,
+          "listingStatus": "FIXED"
+        }
+      ]
+    }
+  }
+}

--- a/src/functionalTest/resources/hearings/update-hearing-request-payload.json
+++ b/src/functionalTest/resources/hearings/update-hearing-request-payload.json
@@ -1,6 +1,7 @@
 {
   "hearingRequest":{
     "listing":{
+      "amendReasonCode": "CNCL",
       "listingAutoCreateFlag":false,
       "listingPriority":"Standard",
       "listingType":"ABA5-FOF",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMIS-1302

### Change description ###

Correct payload for **Create Schedule** is not possible because before calling this endpoint, LA testers need to do some manual activity for a session, so it is not possible to automate it.

Direct Listing is not being used on LA SIT environment which means we cannot write functional test for this endpoint. Configuration is missing on LA side. It is working on TEST environment but our function tests are calling LA SIT environment.

**Does this PR introduce a breaking change?** (check one with "x")
[ ] Yes
[x] No