### PR TITLE
HMIS-1302 Remove checking response text

### DIFF
--- a/src/smokeTest/java/uk/gov/hmcts/reform/hmi/cft/HealthCheckSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/hmi/cft/HealthCheckSmokeTest.java
@@ -21,7 +21,7 @@ class HealthCheckSmokeTest {
     void cftHealthCheckTest() {
         RestClientHelper.performGetRequestAndValidate(
                 "/hmc-health",
-                "Welcome to hmc-hmi-inbound-adapter",
+                "",
                 200
         );
     }

--- a/src/smokeTest/java/uk/gov/hmcts/reform/hmi/crime/HealthCheckSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/hmi/crime/HealthCheckSmokeTest.java
@@ -21,7 +21,7 @@ class HealthCheckSmokeTest {
     void crimeHealthCheckTest() {
         RestClientHelper.performGetRequestAndValidate(
                 "/crime-health",
-                "{“knock-knock”: \"who's there??\"}",
+                "",
                 200
         );
     }

--- a/src/smokeTest/java/uk/gov/hmcts/reform/hmi/internal/HealthCheckSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/hmi/internal/HealthCheckSmokeTest.java
@@ -21,7 +21,7 @@ class HealthCheckSmokeTest {
     void internalHealthCheckTest() {
         RestClientHelper.performGetRequestAndValidate(
                 "/",
-                "\"status\": \"Up\"",
+                "",
                 200
         );
     }

--- a/src/smokeTest/java/uk/gov/hmcts/reform/hmi/la/HealthCheckSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/hmi/la/HealthCheckSmokeTest.java
@@ -21,7 +21,7 @@ class HealthCheckSmokeTest {
     void listAssistHealthCheckTest() {
         RestClientHelper.performGetRequestAndValidate(
                 "/snl-health",
-                " \"database.connectivity\" : \"success\"",
+                " ",
                 200
         );
     }

--- a/src/smokeTest/java/uk/gov/hmcts/reform/hmi/people/HealthCheckSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/hmi/people/HealthCheckSmokeTest.java
@@ -18,7 +18,7 @@ class HealthCheckSmokeTest {
     void peopleHealthCheckTest() {
         RestClientHelper.performGetRequestAndValidate(
                 "/elinks-health",
-                "\"status\":\"OK\"",
+                "",
                 200
         );
     }

--- a/src/smokeTest/java/uk/gov/hmcts/reform/hmi/pip/HealthCheckSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/hmi/pip/HealthCheckSmokeTest.java
@@ -21,7 +21,7 @@ class HealthCheckSmokeTest {
     void pipHealthCheckTest() {
         RestClientHelper.performGetRequestAndValidate(
                 "/pih/health",
-                "Welcome to pip-data-management",
+                "",
                 200
         );
     }

--- a/src/smokeTest/java/uk/gov/hmcts/reform/hmi/vh/HealthCheckSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/hmi/vh/HealthCheckSmokeTest.java
@@ -21,7 +21,7 @@ class HealthCheckSmokeTest {
     void vhHealthCheckTest() {
         RestClientHelper.performGetRequestAndValidate(
                 "/vh-health",
-                "\"successful\":true",
+                "",
                 200
         );
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMIS-1302

### Change description ###

We do not need to compare the response string because sometime consumers of HMI changes the response string but endpoint is still returning success message.

**Does this PR introduce a breaking change?** (check one with "x")
[ ] Yes
[x] No